### PR TITLE
Updated start.sh and Dockerfile

### DIFF
--- a/Docker OpenPIP package/Dockerfile
+++ b/Docker OpenPIP package/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.0-apache
+FROM php:7.4.0-apache
 
 #Install git and MySQL extensions for PHP
 
@@ -11,7 +11,7 @@ ENV APACHE_DOCUMENT_ROOT=/var/www/html/web
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
-COPY ./openPIP/. /var/www/html/
+COPY . /var/www/html/openPIP
 
 EXPOSE 80/tcp
 EXPOSE 443/tcp
@@ -25,7 +25,7 @@ RUN apt-get update && \
     git \
     nano \
     iputils-ping \
-    mysql-client \
+   default-mysql-client \
     locales \
     imagemagick \
     graphicsmagick \
@@ -34,8 +34,8 @@ RUN apt-get update && \
     libxml2-dev libfreetype6-dev \
     libjpeg62-turbo-dev \
     libmcrypt-dev \
-    libpng-dev && \
-    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+    libpng-dev libzip-dev && \
+    docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ && \
     docker-php-ext-install -j$(nproc) mysqli soap gd zip opcache && \
     echo 'always_populate_raw_post_data = -1\nmax_execution_time = 240\nmemory_limit = -1\nmax_input_vars = 1500\nupload_max_filesize = 200M\npost_max_size = 300M' > /usr/local/etc/php/conf.d/typo3.ini && \
 # Configure bash

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-sudo su << SuperUser
-PATH=$PATH:/snap/bin
-chown -R www-data:www-data app/logs &&\
-sudo chmod -R 777 web/uploads &&\ 
-cd .. &&\ 
-docker-compose build &&\ 
+export PATH=$PATH:/snap/bin
+sudo chown -R www-data:www-data app/logs &&
+sudo chmod -R 777 web/uploads &&
+cd ./'Docker OpenPIP package' && 
+docker-compose build &&
 docker-compose up
-SuperUser


### PR DESCRIPTION
## Changes

### In start.sh 
- Cleaned the obsolete backslashes 
- Added the missing "export" command
- Changed the pointing Dockerfile directory to where it was located
- Updated the superuser permissions

### In Dockerfile
- Updated php:7.2.0-apache to php:7.4.0-apache due to deprecated packages.
- Updated the COPY directory location.
- Updated the dependency mysql-client to default-mysql-client due to deprecation issues.
- Added the dependency libzip-dev for libzip
- Updated the deprecated syntax for GD extension for PHP.
---
OS: Ubuntu 23.10 x86_64
Kernel: 6.5.0-9-generic
Shell: bash 5.2.15