### PR TITLE
Fix `yum update` failure

### DIFF
--- a/Docker OpenPIP package/Dockerfile
+++ b/Docker OpenPIP package/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2.0-apache
 
 #Install git and MySQL extensions for PHP
 
-
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 RUN apt-get update && apt-get install -y git
 RUN docker-php-ext-install pdo pdo_mysql mysqli
 RUN a2enmod rewrite


### PR DESCRIPTION
`yum update` command part of dockerfile was failing because the repository had moved to a new hostname. Adding the new hostname for lookup fixed the issue.